### PR TITLE
Fix scheduler startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 from fastapi import FastAPI
 from Services.api.api_client import fetch_data
 from Services.scheduler.scheduler import run_scheduler
+import threading
 
 app = FastAPI()
 
 @app.on_event("startup")
 async def startup_event():
     fetch_data()
-    run_scheduler()
+    threading.Thread(target=run_scheduler, daemon=True).start()


### PR DESCRIPTION
## Summary
- start the scheduler in a background thread so the API doesn't hang

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(cat pyfiles.txt)`
- `python -m py_compile main.py`
- `uvicorn main:app --host 127.0.0.1 --port 8000 --reload` *(validated startup completes)*
